### PR TITLE
yaml has moved to gopkg.in

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/go-yaml/yaml"
+        "gopkg.in/yaml.v1"
 	"io/ioutil"
 	"log"
 	"os"


### PR DESCRIPTION
master is currently failing to compile with the following error:

```
# github.com/go-yaml/yaml
../../go-yaml/yaml/error.go:4: "ERROR: the correct import path is gopkg.in/yaml.v1 ... " evaluated but not used
```

Importing the package from `gopkg.in/yaml.v1` fixes it.
